### PR TITLE
Allow to specify client-side encodibng when connecting to the Oracle database

### DIFF
--- a/README
+++ b/README
@@ -77,6 +77,20 @@ NOTES:
         if your Oracle is not using UTF-8, in which case a value of 2 should
         work for any ISO-8859 character set.
 
+     EnvCharset: integer defaulting to 0
+        Client-side character set id that will be used for the
+        environment handle created upon connecting to the
+        database. Corresponds to the charset argument of the
+        OCIEnvNlsCreate function. Useful when the database uses a
+        different encoding than NaviServer.
+
+     EnvNCharset: integer defaulting to 0
+        Client-side national character set id that will be used for
+        the environment handle created upon connecting to the
+        database. Corresponds to the ncharset argument of the
+        OCIEnvNlsCreate function. Useful when the database uses a
+        different encoding than NaviServer.
+
    ns_ora clob_dml SQL is logged when verbose=on in the pool's configuration
    section.
 

--- a/nsoracle.c
+++ b/nsoracle.c
@@ -2693,6 +2693,20 @@ Ns_DbDriverInit (const char *hdriver, const char *config_path)
     }
     Ns_Log(Notice, "%s driver LobBufferSize = %d", hdriver, lob_buffer_size);
 
+    if (Ns_ConfigGetInt(config_path, "EnvCharset", &config_value)) {
+        env_charset = (ub4)config_value;
+    } else {
+        env_charset = 0;
+    }
+    Ns_Log(Notice, "%s driver EnvCharset = %d", hdriver, env_charset);
+
+    if (Ns_ConfigGetInt(config_path, "EnvNCharset", &config_value)) {
+        env_ncharset = (ub4)config_value;
+    } else {
+        env_ncharset = 0;
+    }
+    Ns_Log(Notice, "%s driver EnvNCharset = %d", hdriver, env_ncharset);
+
     if (!Ns_ConfigGetInt(config_path, "PrefetchRows", &prefetch_rows))
         prefetch_rows = 0;
     Ns_Log(Notice, "%s driver PrefetchRows = %d", hdriver, prefetch_rows);
@@ -2849,14 +2863,17 @@ Ns_OracleOpenDb (Ns_DbHandle *dbh)
      */
     dbh->connection = connection;
 
-    oci_status = OCIEnvCreate(&connection->env,
-                              OCI_THREADED|OCI_ENV_NO_MUTEX,
-                              NULL,
-                              Ns_OracleMalloc,
-                              Ns_OracleRealloc,
-                              Ns_OracleFree,
-                              0, 0);
-    if (oci_error_p(lexpos(), NULL, "OCIEnvCreate", 0, oci_status))
+    oci_status = OCIEnvNlsCreate(&connection->env,
+                                 OCI_THREADED|OCI_ENV_NO_MUTEX,
+                                 NULL,
+                                 Ns_OracleMalloc,
+                                 Ns_OracleRealloc,
+                                 Ns_OracleFree,
+                                 0,
+                                 0,
+                                 env_charset,
+                                 env_ncharset);
+    if (oci_error_p(lexpos(), NULL, "OCIEnvNlsCreate", 0, oci_status))
         return NS_ERROR;
 
 

--- a/nsoracle.h
+++ b/nsoracle.h
@@ -315,6 +315,8 @@ static bool debug_p = NS_FALSE;
 static int max_string_log_length = 0;
 static unsigned int lob_buffer_size = 16384;
 static int char_expansion;
+static ub2 env_charset;
+static ub2 env_ncharset;
 
 /* Prefetch parameters, if zero leave defaults */
 static int prefetch_rows = 0;


### PR DESCRIPTION
 - Replace OCIEnvCreate with OCIEnvNlsCreate
 - Introduce two new configuration options corresponding to the extra arguments OCIEnvNlsCreate allows to specify: EnvCharset -> charset and EnvNXCharset -> ncharset

This allows scenarios where the database is encoded differently from NaviServer.

I create this as a draft because we still need to test it. In the meantime, feel free to comment.

One possible improvement would be to specify the client encoding via its human-readable name, but I could not find an idiom that would just do that, it seems one needs either an environment or a handle to already exist... but maybe I am wrong.

See e.g. https://docs.oracle.com/en/database/oracle/oracle-database/21/lnoci/oci-locale-functions.html#GUID-6C255C8A-180F-4328-9300-CE7BA9BEEE6D